### PR TITLE
Fix getRequest() deprecation warning

### DIFF
--- a/idkbse/IdkbsePlugin.inc.php
+++ b/idkbse/IdkbsePlugin.inc.php
@@ -53,7 +53,7 @@ class IdkbsePlugin extends GenericPlugin {
 	}
 
 	function handleFormDisplay($hookName, $args) {
-		$request = PKPApplication::getRequest();
+		$request = Application::get()->getRequest();
 		$templateMgr = TemplateManager::getManager($request);
 		$template =& $args[1];
 		switch ($template) {


### PR DESCRIPTION
I got a ton of these deprecation notices in the server log (I think this would be fatal if we were using PHP 8):
```
PHP Deprecated:  Non-static method PKPApplication::getRequest() should not be called statically in /home/andersju/kungbib/idkbse-ojs-plugin/idkbse/IdkbsePlugin.inc.php on line 56
```
This fixes that.